### PR TITLE
Migrate to optimist

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,6 @@
 require 'rubygems'
 require 'hoe'
 
-Hoe.plugin :rubyforge
-
 Hoe.spec 'patience_diff' do
   developer "Andrew Watt", "andrew@wattornot.com"
   dependency "trollop", "~> 1.16"

--- a/Rakefile
+++ b/Rakefile
@@ -4,4 +4,5 @@ require 'hoe'
 Hoe.spec 'patience_diff' do
   developer "Andrew Watt", "andrew@wattornot.com"
   dependency "optimist", "~> 3.0"
+  license "MIT"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,5 +3,5 @@ require 'hoe'
 
 Hoe.spec 'patience_diff' do
   developer "Andrew Watt", "andrew@wattornot.com"
-  dependency "trollop", "~> 1.16"
+  dependency "optimist", "~> 3.0"
 end

--- a/bin/patience_diff
+++ b/bin/patience_diff
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 require 'English'
 require 'pathname'
-require 'trollop'
+require 'optimist'
 
 lib_path = Pathname(File.join(File.dirname(__FILE__),"..","lib")).realpath
 $LOAD_PATH.unshift(lib_path)
@@ -9,25 +9,25 @@ require 'patience_diff'
 
 begin
   program_name = File.basename($PROGRAM_NAME)
-  opts = Trollop::options do
+  opts = Optimist::options do
     banner <<-EOF.gsub(/^\s*/, '')
       Usage: #{program_name} [options] left-file right-file (left-file-2 right-file-2 ...)
       Options:
     EOF
-    
+
     version "#{program_name} #{PatienceDiff::VERSION}"
-    
+
     opt :debug, "Debugging mode"
     opt :context, "Lines of context", :default => 3
     opt :all_context, "Don't collapse common sections; output entire files. Ignored in html format."
     opt :format, "Specify output format. Currently 'text' and 'html' are supported.", :default => "text"
-    opt :ignore_whitespace, 
+    opt :ignore_whitespace,
       "Ignore trailing whitespace, and treat leading whitespace as either present or not. This switch is for compatibility with diff's -b option.",
       :short => '-b'
   end
-  
+
   raise PatienceDiff::UsageError unless ARGV.length and ARGV.length % 2 == 0
-  
+
   differ = PatienceDiff::Differ.new(opts)
   formatter = case opts.delete(:format)
     when 'text'
@@ -37,7 +37,7 @@ begin
     else
       raise PatienceDiff::UsageError
     end.new(differ)
-  
+
   formatter.format do |diff|
     ARGV.each_slice(2) do |(left_file, right_file)|
       diff.files left_file, right_file
@@ -45,7 +45,7 @@ begin
   end.tap do |result|
     print result
   end
-  
+
 rescue PatienceDiff::UsageError => e
   Trollop.module_eval do
     @last_parser.educate($stderr)


### PR DESCRIPTION
Hey! One of this projects dependencies has been renamed. This PR reflects that, adds an explicit license and removes the RubyForge plugin, since RubyForge hasn't been a thing for a couple of years now.